### PR TITLE
Fixed history command to properly append text instead of cutting it u…

### DIFF
--- a/FTPClient/Commands/DefaultCommands.cs
+++ b/FTPClient/Commands/DefaultCommands.cs
@@ -1,13 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
-using System.Security.Cryptography;
-using System.IO;
-using System.Linq;
 using System.IO;
 using DiffMatchPatch;
-using System.Collections.Generic;
-using System.Globalization;
 using FluentFTP;
 
 namespace FTPClient.Commands
@@ -50,7 +45,7 @@ namespace FTPClient.Commands
             }
             catch (Exception e)
             {
-                returnMessage = "Connection failed with Exception";
+                returnMessage = "Connection failed with Exception:" + e;
             }
 
             return returnMessage;
@@ -82,7 +77,7 @@ namespace FTPClient.Commands
             }
             catch (Exception e)
             {
-                returnMessage = "Server not connected Or Listing failed with Exception";
+                returnMessage = "Server not connected Or Listing failed with Exception:" + e;
             }
             return returnMessage;
         }
@@ -110,7 +105,7 @@ namespace FTPClient.Commands
             }
             catch (Exception e)
             {
-                returnMessage = "Listing of local directories and files failed with Exception";
+                returnMessage = "Listing of local directories and files failed with Exception: " + e;
             }
             return returnMessage;
         }
@@ -133,7 +128,7 @@ namespace FTPClient.Commands
             }
             catch (Exception e)
             {
-                returnMessage = "Rename failed with exception";
+                returnMessage = "Rename failed with exception: " + e;
             }
             return returnMessage;
         }
@@ -142,7 +137,6 @@ namespace FTPClient.Commands
         public static string mvLocal(string target, string name)
         {
             string returnMessage = "";
-            string res = "";
             try
             {
                 var currentdir = System.IO.Directory.GetCurrentDirectory();
@@ -230,7 +224,7 @@ namespace FTPClient.Commands
             }
             catch (Exception e)
             {
-                returnMessage = "The File does not exist";
+                returnMessage = "The File does not exist: " + e;
             }
 
             return returnMessage;

--- a/FTPClient/Console/Console.cs
+++ b/FTPClient/Console/Console.cs
@@ -56,8 +56,7 @@ namespace FTPClient.Console
                     // Create a ConsoleCommand instance:
                     var cmd = new ConsoleCommand(consoleInput);
 
-                    //Write command history to log file
-                    writeToHistory = new FileStream("./history.txt", FileMode.OpenOrCreate, FileAccess.Write);
+                    writeToHistory = new FileStream("./history.txt", FileMode.Append, FileAccess.Write);
                     writer = new StreamWriter(writeToHistory);
                     writer.WriteLine(consoleInput);
                     writer.Close();
@@ -158,7 +157,7 @@ namespace FTPClient.Console
                         string argumentTypeName = typeRequired.Name;
                         string message =
                             string.Format(""
-                            + "The value passed for argument '{0}' cannot be parsed to type '{1}'",
+                            + "The value passed for argument '{0}' cannot be parsed to type '{1}': " + ex,
                             argumentName, argumentTypeName);
                         throw new ArgumentException(message);
                     }

--- a/FTPClient/FTPClient.csproj.user
+++ b/FTPClient/FTPClient.csproj.user
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_LastSelectedProfileId>C:\Users\Samur\source\repos\Agile_FTP_Client\FTPClient\Properties\PublishProfiles\FolderProfile.pubxml</_LastSelectedProfileId>
+  </PropertyGroup>
+</Project>

--- a/FTPClient/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/FTPClient/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <PublishDir>bin\Debug\netcoreapp2.2\publish\</PublishDir>
+  </PropertyGroup>
+</Project>

--- a/FTPClient/Properties/PublishProfiles/FolderProfile.pubxml.user
+++ b/FTPClient/Properties/PublishProfiles/FolderProfile.pubxml.user
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+</Project>


### PR DESCRIPTION
…p.  Removed some of the suppressed warnings from our catch statements.  Verified functionality of both history and mv when used as a .exe